### PR TITLE
docs: add Home tab linking to the landing page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,6 +54,12 @@ Quickstart
 
 .. toctree::
    :hidden:
+   :caption: Home
+
+   self
+
+.. toctree::
+   :hidden:
    :caption: Getting Started
 
    readme


### PR DESCRIPTION
Add a 'Home' toctree entry (using the 'self' reference) so the sphinx-immaterial top navigation exposes a Home tab that returns to the documentation landing page. The tab renders as the leftmost entry and links back to index from every sub-page.