### PR TITLE
docs: Welcome page, Authors, User Guide overview, consolidated example data, and gallery refactor

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,13 +1,23 @@
-======
-QUENDS
-======
+=================
+Welcome to QUENDS
+=================
 
 |maintained| |python-tests| |deployment| |python| |license| |black| |coveralls|
 
-**QUENDS** (Quantifying Uncertainty in ENsemble Data Streams) turns raw
-time-series simulation output into trustworthy statistics: it trims transients,
-detects steady state, and quantifies uncertainty for single signals and for
-ensembles of runs.
+**QUENDS** : *Quantifying Uncertainty in ENsemble Data Streams*, is a
+Python-based framework for analyzing time-series outputs from simulations and
+experiments. It helps transform raw, noisy data streams into reliable
+statistical summaries by identifying and trimming transient behavior, detecting
+steady-state regions, and estimating uncertainty in both single-run and
+ensemble simulation outputs.
+
+QUENDS is designed for workflows where simulation outputs evolve over time and
+where trustworthy post-processing is needed before drawing conclusions. The
+framework supports single-trace analysis, ensemble-based analysis, steady-state
+detection, transient trimming, statistical estimation, and uncertainty
+quantification. By combining these capabilities into a unified workflow, QUENDS
+provides researchers with a reproducible way to move from raw simulation data to
+meaningful, uncertainty-aware results.
 
 Quickstart
 ==========


### PR DESCRIPTION
Documentation and examples overhaul building on the Home-tab change in #195.

**Landing page (`docs/index.rst`)**
- Heading renamed to **Welcome to QUENDS** with a fuller two-paragraph overview.
- New **Authors** section crediting the maintainers, with a link to the full author list.

**User Guide (`docs/user_guide/index.md`)**
- Expanded the topic table to **Topic / Module / Purpose**, adding Core concepts, Single-trace analysis, Method selection, and Troubleshooting rows; existing sections retained.

**Example data (`examples/tutorial/data/`)**
- New consolidated layout: `data/cgyro/` (CSV outputs only) and `data/gx/` (8 ensemble runs from the stellarator t=1200 ensemble).
- Removed the superseded mixed `gx/` and `cgyro/` folders (PDFs + notebook).

**Gallery of Examples (`examples/tutorial/datastream_guide.py`)**
- Rebuilt around the new data: a single-trace GX walkthrough (load → raw plot → stationarity → trim shown both ways → steady-state plot → ESS → statistics), an ensemble walkthrough (members-with-average plot, then Ensemble Average / Serialization / IVW approaches), an 'other input scenarios' section (already-trimmed data; non-stationary / failed detection), UQ analysis, and CGYRO.
- Trim/statistics parameters follow the QUENDS paper notebooks.

**README**
- Pointed the 'official documentation' link at the docs home instead of the raw AutoAPI module page.

Builds clean under `sphinx-build -W --keep-going`; sphinx-gallery executes the tutorial and captures all five figures.